### PR TITLE
Add UPN property to `deployer()`

### DIFF
--- a/active/0009-deployment-principal-function.md
+++ b/active/0009-deployment-principal-function.md
@@ -51,8 +51,9 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 ## Detailed design
 - We plan to expose a minimal set of properties to satisfy the above use-cases, namely:
     - `objectId` - represents the unique identifier of the principal within a tenant
-    - `type` - i.e. `User`, `ServicePrincipal`
+    - `type` - i.e. `User`, `ServicePrincipal` (this is on-hold as ARM does not currently propagate the x-ms header for the principal type)
     - `tenantId` - represents the tenant where the user/service principal is managed
+    - `userPrincipalName` - NOTE: this will only exist for principal of type _User_
 - By scoping it down to these properties, this should make the implementation easier, as we can access these values via headers, and not have to make outgoing requests to MSGraph.
 
 ### Client side changes


### PR DESCRIPTION
Impetus for adding this -> https://github.com/microsoftgraph/msgraph-bicep-types/issues/135#issuecomment-2569134452

The UPN is available from ARM headers as [`x-ms-client-principal-name`](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md). It will be populated [for users but not service principals](https://stackoverflow.microsoft.com/a/241176/172688).