### PR TITLE
Finalize REPs 0009 and 0013 and fix formatting

### DIFF
--- a/0000-rep-template.md
+++ b/0000-rep-template.md
@@ -1,13 +1,13 @@
 ---
-REP Number: <Fill me in with a four-digit number in double quotes (otherwise it's octal) matching the pull request number; Update AFTER PR is approved and BEFORE is merged.>
+REP Number: "<Fill me in with a four-digit number matching the pull request number; update AFTER the PR is approved and BEFORE it is merged.>"
 Author: <github username (First Name and Last Name)>
 Start Date: <Today's Date, YYYY-MM-DD>
 Feature Status: <Private Preview | Public Preview | Public>
-Bicep Issue Number(s): <Fill if the REP originates from one or more Bicep issues; otherwise, delete.>
-Enhances: <Fill an existing final REP number if this REP enhances it; otherwise, delete.>
-Deprecates: <Fill an existing final REP number if this REP deprecates it; otherwise, delete.>
-Enhanced By: <Applicable to existing final REPs only. Fill a final REP number if that REP enhances this one. Delete for new REPs.>
-Deprecated By: <Applicable to existing final REPs only. Fill a final REP number if that REP deprecates this one. Delete for new REPs.>
+Bicep Issue Number(s): "<Fill if the REP originates from one or more Bicep issues; otherwise, delete.>"
+Enhances: "<Fill an existing final REP number if this REP enhances it; otherwise, delete.>"
+Deprecates: "<Fill an existing final REP number if this REP deprecates it; otherwise, delete.>"
+Enhanced By: "<Applicable to existing final REPs only. Fill a final REP number if that REP enhances this one. Delete for new REPs.>"
+Deprecated By: "<Applicable to existing final REPs only. Fill a final REP number if that REP deprecates this one. Delete for new REPs.>"
 ---
 
 <!-- Remove this comment and the prompts (in the form of blockquotes) for each section before submitting your PR -->

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ stateDiagram-v2
     Draft --> Review: Review the PR
     Review --> Active: PR accepted
     Review --> Rejected: PR rejected and closed
-    Active --> Active: Create new PRs to\n make revisions
+    Active --> Active: Create new PRs to<br/>make revisions
     Active --> Final: Feature fully implemented
-    Active --> Deferred: Not enough feedback\n has been received to\n finalize the feature
+    Active --> Deferred: Not enough feedback<br/>has been received to<br/>finalize the feature
     Final --> Deprecated: REP superceded by a new REP
     Rejected --> [*]
 ```

--- a/active/0002-centalized-mgmt-resource-types-provider-versions.md
+++ b/active/0002-centalized-mgmt-resource-types-provider-versions.md
@@ -1,9 +1,9 @@
 ---
-REP Number: 0002
+REP Number: "0002"
 Author: asilverman (Ariel Silverman)
 Start Date: 2023-12-19
 Feature Status: Private Preview
-Bicep Issue Number(s): [12202](https://github.com/Azure/bicep/issues/12202)
+Bicep Issue Number(s): "[12202](https://github.com/Azure/bicep/issues/12202)"
 ---
 
 # Title - Centralized management of resource type provider versions using bicepconfig.json

--- a/active/0006-extensibility-support-for-deployment-stacks.md
+++ b/active/0006-extensibility-support-for-deployment-stacks.md
@@ -1,5 +1,5 @@
-﻿---
-REP Number: 0006
+---
+REP Number: "0006"
 Author: kalbert312 (Kyle Albert)
 Start Date: 2024-08-27
 Feature Status: Public Preview

--- a/active/0010-custom-validation-decorators.md
+++ b/active/0010-custom-validation-decorators.md
@@ -1,5 +1,5 @@
 ---
-REP Number: 0010
+REP Number: "0010"
 Author: jeskew (Jonathan Eskew)
 Start Date: 2024-10-29
 Feature Status: Public Preview

--- a/final/0009-deployment-principal-function.md
+++ b/final/0009-deployment-principal-function.md
@@ -1,9 +1,9 @@
 ---
-REP Number: 0009
+REP Number: "0009"
 Author: levimatheri (Levi Muriuki)
 Start Date: 2024-09-09
-Feature Status: Private Preview
-Bicep Issue Number(s): [#645](https://github.com/Azure/bicep/issues/645), [#4959](https://github.com/Azure/bicep/issues/4959), [#9969](https://github.com/Azure/bicep/discussions/9969)
+Feature Status: Public
+Bicep Issue Number(s): "[#645](https://github.com/Azure/bicep/issues/645), [#4959](https://github.com/Azure/bicep/issues/4959), [#9969](https://github.com/Azure/bicep/discussions/9969)"
 ---
 
 # Title - New deployment principal function

--- a/final/0013-decorator-transformations.md
+++ b/final/0013-decorator-transformations.md
@@ -1,5 +1,5 @@
 ---
-REP Number: '0013'
+REP Number: "0013"
 Author: anthony-c-martin (Anthony Martin)
 Start Date: 2025-01-23
 Feature Status: Public


### PR DESCRIPTION
## Summary

- Move REPs 0009 and 0013 from `active/` to `final/` and mark REP 0009 as public.
- Remove the obsolete `final/.gitkeep` placeholder.
- Fix YAML front matter across the existing REPs and harden the REP template by quoting YAML-sensitive values and removing the BOM from REP 0006.

## Validation

- Parsed the template and all REP front matter with Ruby's YAML parser.
- Ran `git diff HEAD^ HEAD --check`.